### PR TITLE
openDirectory bug fix in /fugu-edit 

### DIFF
--- a/fugu-edit/src/js/lib/files.js
+++ b/fugu-edit/src/js/lib/files.js
@@ -42,7 +42,7 @@ export async function selectFile(code, state) {
 export async function selectFolder(code) {
   try {
     const handler = await window.chooseFileSystemEntries({
-      type: 'openDirectory',
+      type: 'open-directory',
     });
 
     const tree = [


### PR DESCRIPTION
It's seems that type spelling have been changed according to docs
https://web.dev/native-file-system/#open-a-directory-and-enumerate-its-contents